### PR TITLE
Fix compilation error "unknown type name 'intptr_t'" on linux.

### DIFF
--- a/include/dieharder/libdieharder.h
+++ b/include/dieharder/libdieharder.h
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
 #include <sys/time.h>


### PR DESCRIPTION
In order to successfully compile dieharder in Arch Linux it is necessary to include stdint.h.
[intptr_t and uintptr_t are optional C99 types.](https://stackoverflow.com/questions/9042024/error-unknown-type-name-intptr-t)